### PR TITLE
Add lower case warning for backend name

### DIFF
--- a/docs/markdown/backend/overview.md
+++ b/docs/markdown/backend/overview.md
@@ -1,6 +1,7 @@
 # 💽 Backends
 
 Backends are the outputs of the backup process. Each location needs at least one.
+Note: names of backends MUST be lower case!
 
 ```yaml | .autorestic.yml
 version: 2


### PR DESCRIPTION
If uppercase characters are used in a backend name a check (and I assume other actions) will fail.